### PR TITLE
fixes to new script-prototypes compiler warnings

### DIFF
--- a/apg/apg.h
+++ b/apg/apg.h
@@ -296,7 +296,7 @@ LOG FILES
 #endif
 
 /** Open/refresh a new log file and print timestamp. */
-void apg_start_log();
+void apg_start_log( void );
 
 /** Write a log entry. */
 void apg_log( const char* message, ... ) ATTRIB_PRINTF( 1, 2 );
@@ -839,7 +839,7 @@ LOG FILES IMPLEMENTATION
 =================================================================================================*/
 #define APG_LOG_FILE "apg.log" /* file name for log */
 
-void apg_start_log() {
+void apg_start_log( void ) {
   FILE* file = fopen( APG_LOG_FILE, "w" ); /* NOTE it was getting massive with "a" */
   if ( !file ) {
     fprintf( stderr, "ERROR: could not open APG_LOG_FILE log file %s for writing\n", APG_LOG_FILE );
@@ -973,7 +973,7 @@ void apg_print_trace( FILE* stream ) {
 } /* endfunc apg_print_trace() */
 
 /* to deliberately cause a sigsegv: call a function containing bad ptr: int *foo = (int*)-1; */
-void apg_start_crash_handler() {
+void apg_start_crash_handler( void ) {
   signal( SIGSEGV, _crash_handler );
   signal( SIGABRT, _crash_handler ); /* assert */
   signal( SIGILL, _crash_handler );

--- a/apg/tests/apg.c
+++ b/apg/tests/apg.c
@@ -366,7 +366,7 @@ LOG FILES IMPLEMENTATION
 =================================================================================================*/
 #define APG_LOG_FILE "apg.log" /* file name for log */
 
-void apg_start_log() {
+void apg_start_log( void ) {
   FILE* file = fopen( APG_LOG_FILE, "w" ); /* NOTE it was getting massive with "a" */
   if ( !file ) {
     fprintf( stderr, "ERROR: could not open APG_LOG_FILE log file %s for writing\n", APG_LOG_FILE );

--- a/apg/tests/hash_test.c
+++ b/apg/tests/hash_test.c
@@ -12,7 +12,7 @@ Language: C99
 
 #define N_STORE 666
 
-int main() {
+int main( void ) {
   printf( "===========================================\n" );
   {
     apg_hash_table_t table = apg_hash_table_create( 128 );

--- a/apg/tests/rle_test.c
+++ b/apg/tests/rle_test.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main() {
+int main( void ) {
   const char* input_buffer  = "ABBCCCDDDDEEEEEFFFFFFGGGGGGGHHHHHHHHIIIIIIIII";
   char* decompressed_buffer = NULL;
 

--- a/apg_console/apg_console.c
+++ b/apg_console/apg_console.c
@@ -1,7 +1,7 @@
 /* =======================================================================================================================
 APG_C - A Quake-style Console mini-library
 Author:   Anton Gerdelan - @capnramses
-Version:  0.13
+Version:  0.13.1
 Language: C99
 Licence:  See bottom of header file.
 ======================================================================================================================= */
@@ -64,8 +64,6 @@ static void apg_c_strncat( char* dst, const char* src, const int dest_max_len, c
   int dst_len         = apg_c_strnlen( dst, dest_max_len );
   dst[dst_len]        = '\0'; // just in case it wasn't already terminated before max length
   int remaining_space = dest_max_len - dst_len;
-  if ( remaining_space <= 0 ) { return; }
-  if ( remaining_space <= 0 ) { return; }
   const int n = remaining_space < src_max_copy ? remaining_space : src_max_copy; // use src_max if smaller
   strncat( dst, src, n - 1 );                                                    // strncat manual guarantees null termination.
 }
@@ -80,17 +78,17 @@ static void _apg_c_command_hist_append( const char* c_user_entered_text ) {
   if ( _c_command_history_n >= APG_C_MAX_COMMAND_HIST ) { _c_command_history_n = APG_C_MAX_COMMAND_HIST - 1; }
 }
 
-static void _help() {
+static void _help( void ) {
   apg_c_printf( "APG_C by Anton Gerdelan. Autocomplete supported. Built-in functions are:" );
   for ( int i = 0; i < APG_C_N_BUILT_IN_COMMANDS; i++ ) { apg_c_printf( "%s", _c_built_in_commands[i] ); }
 }
 
-static void _list_c_vars() {
+static void _list_c_vars( void ) {
   apg_c_printf( "=====c_vars=====" );
   for ( uint32_t i = 0; i < _n_c_vars; i++ ) { apg_c_printf( "%s", _c_vars[i].str ); }
 }
 
-static void _list_c_funcs() {
+static void _list_c_funcs( void ) {
   apg_c_printf( "=====c_funcs=====" );
   for ( uint32_t i = 0; i < _n_c_funcs; i++ ) { apg_c_printf( "%s", _c_funcs[i].str ); }
 }
@@ -281,13 +279,13 @@ void apg_c_reuse_hist( int hist_steps ) {
   _c_redraw_required = true;
 }
 
-void apg_c_reuse_hist_back_one() {
+void apg_c_reuse_hist_back_one( void ) {
   _hist_curr_rewind_idx++;
   if ( _hist_curr_rewind_idx >= _c_command_history_n ) { _hist_curr_rewind_idx = _c_command_history_n - 1; }
   apg_c_reuse_hist( _hist_curr_rewind_idx );
 }
 
-void apg_c_reuse_hist_ahead_one() {
+void apg_c_reuse_hist_ahead_one( void ) {
   _hist_curr_rewind_idx--;
   if ( _hist_curr_rewind_idx < 0 ) { _hist_curr_rewind_idx = 0; }
   apg_c_reuse_hist( _hist_curr_rewind_idx );
@@ -308,7 +306,7 @@ void apg_c_clear_user_entered_text( void ) {
 }
 
 // WARNING(Anton) - assumes string is ASCII
-void apg_c_autocomplete() {
+void apg_c_autocomplete( void ) {
   size_t len = strlen( _c_user_entered_text );
   if ( 0 == len ) { return; }
 
@@ -521,4 +519,4 @@ bool apg_c_draw_to_image_mem( uint8_t* img_ptr, int w, int h, int n_channels, ui
   return true;
 }
 
-bool apg_c_image_redraw_required() { return _c_redraw_required; }
+bool apg_c_image_redraw_required( void ) { return _c_redraw_required; }

--- a/apg_console/apg_console.h
+++ b/apg_console/apg_console.h
@@ -8,19 +8,20 @@ Contact:  <antongdl@protonmail.com>
 Website:  https://github.com/capnramses/apg - http://antongerdelan.net/
 Licence:  See bottom of this file.
 Version History:
-  v0.13 - 2022/09/23 - Updated API to match new apg_pixfont.
-  v0.12 - 2021/10/03 - Fix to missing nul-terminator in long string copies.
-  v0.11 - 2021/06/09 - Fixes to warnings reported by MSVC.
-  v0.10 - 2021/06/05 - Fixed strncat warnings.
-  v0.9  - 2020/11/08 - Added functions to iteratively scroll through history like in BaSh.
-  v0.8  - 2020/09/13 - Removed assert on append empty string. Reduced max str len to suit shorter consoles.
-  v0.7  - 2020/08/09 - Fixed bug where counter of number of built in commands was too high by 1. Updated docs in this file.
-  v0.6  - 2020/08/08 - Fixed issue/bug where dumping to stdout didn't print current user entered text if history was empty.
-  v0.5  - 2020/08/08 - apc_c_printf_rgba() to set the colour of particular lines. History text is now grey by default, and cursor text is white.
-  v0.4  - 2020/08/08 - Added printf-style variadic arguments and renamed apc_c_print() to apc_c_printf().
-  v0.3  - 2020/06/07 - Doubled length of tmp strings to avoid truncation warnings.
-  v0.2  - 2020/01/04 - Moved to apg libraries repository. Minor tweaks from testing in a game integration.
-  v0.1  - 2020/01/06 - Reduced interface. Moved from stored float cvars to addresses of existing vars. Data type is also specified for bool/int/uint/float support.
+  v0.13.1 - 2023/04/19 - Small function prototype fixes.
+  v0.13   - 2022/09/23 - Updated API to match new apg_pixfont.
+  v0.12   - 2021/10/03 - Fix to missing nul-terminator in long string copies.
+  v0.11   - 2021/06/09 - Fixes to warnings reported by MSVC.
+  v0.10   - 2021/06/05 - Fixed strncat warnings.
+  v0.9    - 2020/11/08 - Added functions to iteratively scroll through history like in BaSh.
+  v0.8    - 2020/09/13 - Removed assert on append empty string. Reduced max str len to suit shorter consoles.
+  v0.7    - 2020/08/09 - Fixed bug where counter of number of built in commands was too high by 1. Updated docs in this file.
+  v0.6    - 2020/08/08 - Fixed issue/bug where dumping to stdout didn't print current user entered text if history was empty.
+  v0.5    - 2020/08/08 - apc_c_printf_rgba() to set the colour of particular lines. History text is now grey by default, and cursor text is white.
+  v0.4    - 2020/08/08 - Added printf-style variadic arguments and renamed apc_c_print() to apc_c_printf().
+  v0.3    - 2020/06/07 - Doubled length of tmp strings to avoid truncation warnings.
+  v0.2    - 2020/01/04 - Moved to apg libraries repository. Minor tweaks from testing in a game integration.
+  v0.1    - 2020/01/06 - Reduced interface. Moved from stored float cvars to addresses of existing vars. Data type is also specified for bool/int/uint/float support.
 
 Instructions
 ============
@@ -125,10 +126,10 @@ PARAMS - hist is the number of entries back from the most recent command entered
 void apg_c_reuse_hist( int hist_steps );
 
 /* Call this function on i.e. user hitting cursor up arrow to replicate BaSh history scrolling. Calls apg_c_reuse_hist() with the appropriate history item. */
-void apg_c_reuse_hist_back_one();
+void apg_c_reuse_hist_back_one( void );
 
 /* Call this function on i.e. user hitting cursor down arrow to replicate BaSh history scrolling. */
-void apg_c_reuse_hist_ahead_one();
+void apg_c_reuse_hist_ahead_one( void );
 
 void apg_c_clear_user_entered_text( void );
 
@@ -195,7 +196,7 @@ rendering API
 bool apg_c_draw_to_image_mem( uint8_t* img_ptr, int w, int h, int n_channels, uint8_t* background_colour );
 
 // RETURNS true if console has changed since last call to apg_c_draw_to_image_mem() and can be painted again
-bool apg_c_image_redraw_required();
+bool apg_c_image_redraw_required( void );
 
 #ifdef __cplusplus
 }

--- a/apg_console/tests/main.c
+++ b/apg_console/tests/main.c
@@ -10,7 +10,7 @@ bool anton_func( const char* arg_str ) {
   return true;
 }
 
-int main() {
+int main( void ) {
 
   // resolving a prior bug where text wouldn't print until a \n was entered
   apg_c_append_user_entered_text( "does this print without a slash n?" );

--- a/apg_gldb/apg_gldb.c
+++ b/apg_gldb/apg_gldb.c
@@ -1,5 +1,5 @@
 /*
-OpenGL Debug Drawing Functions
+OpenGL Debug Drawing Functions v0.4.1
 https://github.com/capnramses/opengl_debug_draw
 Anton Gerdelan <antonofnote@gmail.com>
 LICENCE - See bottom of header file.
@@ -39,9 +39,9 @@ static const char* gl_db_lines_fs_str =
   "  gl_FragColor = fc;\n"
   "}";
 
-void apg_gldb_reset_lines() { _count_lines = 0; }
+void apg_gldb_reset_lines( void ) { _count_lines = 0; }
 
-bool apg_gldb_init() {
+bool apg_gldb_init( void ) {
   // vao for drawing properties of lines
   glGenVertexArrays( 1, &_lines_vao );
   glBindVertexArray( _lines_vao );
@@ -85,14 +85,14 @@ bool apg_gldb_init() {
   return true;
 }
 
-void apg_gldb_free() {
+void apg_gldb_free( void ) {
   glDeleteBuffers( 1, &_lines_vbo );
   glDeleteVertexArrays( 1, &_lines_vao );
   // attached shaders have prev been flagged to delete so will also be deleted
   glDeleteProgram( _lines_shader_program );
 }
 
-int apg_gldb_add_line( float* start_xyz, float* end_xyz, float* colour_rgba ) {
+int apg_gldb_add_line( const float* start_xyz, const float* end_xyz, const float* colour_rgba ) {
   if ( _count_lines >= APG_GLDB_MAX_LINES ) {
     fprintf( stderr, "ERROR: too many apg_gldb lines\n" );
     return -1;
@@ -122,7 +122,7 @@ int apg_gldb_add_line( float* start_xyz, float* end_xyz, float* colour_rgba ) {
   return _count_lines++;
 }
 
-int apg_gldb_add_normal( float* n_xyz, float* pos_xyz, float scale, float* colour_rgba ) {
+int apg_gldb_add_normal( const float* n_xyz, const float* pos_xyz, float scale, const float* colour_rgba ) {
   if ( _count_lines >= APG_GLDB_MAX_LINES ) {
     fprintf( stderr, "ERROR: too many apg_gldb lines\n" );
     return -1;
@@ -156,7 +156,7 @@ int apg_gldb_add_normal( float* n_xyz, float* pos_xyz, float scale, float* colou
   return _count_lines++;
 }
 
-int apg_gldb_add_pos( float* pos_xyz, float scale, float* colour_rgba ) {
+int apg_gldb_add_pos( const float* pos_xyz, float scale, const float* colour_rgba ) {
   int rid = -1;
   float start[3], end[3];
 
@@ -185,7 +185,7 @@ int apg_gldb_add_pos( float* pos_xyz, float scale, float* colour_rgba ) {
   return rid;
 }
 
-int apg_gldb_add_aabb( float* min_xyz, float* max_xyz, float* colour_rgba ) {
+int apg_gldb_add_aabb( const float* min_xyz, const float* max_xyz, const float* colour_rgba ) {
   int rid = -1;
   float start[3], end[3];
 
@@ -244,7 +244,7 @@ int apg_gldb_add_aabb( float* min_xyz, float* max_xyz, float* colour_rgba ) {
   return rid;
 }
 
-int apg_gldb_add_rad_circle( float* centre_xyz, float radius, float* colour_rgba ) {
+int apg_gldb_add_rad_circle( const float* centre_xyz, float radius, const float* colour_rgba ) {
   int rid = -1;
   float start[3], end[3];
   // 3 radius lines in a cross first
@@ -273,39 +273,40 @@ int apg_gldb_add_rad_circle( float* centre_xyz, float radius, float* colour_rgba
   int segs = 12;
   // x,y around z loop
   for ( int i = 0; i < segs; i++ ) {
-    start[0] = centre_xyz[0] + radius * cos( 2.0f * APG_GLDB_PI * (float)i / (float)segs );
-    start[1] = centre_xyz[1] + radius * sin( 2.0f * APG_GLDB_PI * (float)i / (float)segs );
+    start[0] = centre_xyz[0] + radius * cosf( 2.0f * (float)APG_GLDB_PI * (float)i / (float)segs );
+    start[1] = centre_xyz[1] + radius * sinf( 2.0f * (float)APG_GLDB_PI * (float)i / (float)segs );
     start[2] = centre_xyz[2];
-    end[0]   = centre_xyz[0] + radius * cos( 2.0f * APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
-    end[1]   = centre_xyz[1] + radius * sin( 2.0f * APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
+    end[0]   = centre_xyz[0] + radius * cosf( 2.0f * (float)APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
+    end[1]   = centre_xyz[1] + radius * sinf( 2.0f * (float)APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
     end[2]   = centre_xyz[2];
     apg_gldb_add_line( start, end, colour_rgba );
   }
   // x,z around y loop
   for ( int i = 0; i < segs; i++ ) {
-    start[0] = centre_xyz[0] + radius * cos( 2.0f * APG_GLDB_PI * (float)i / (float)segs );
+    start[0] = centre_xyz[0] + radius * cosf( 2.0f * (float)APG_GLDB_PI * (float)i / (float)segs );
     start[1] = centre_xyz[1];
-    start[2] = centre_xyz[2] + radius * sin( 2.0f * APG_GLDB_PI * (float)i / (float)segs );
-    end[0]   = centre_xyz[0] + radius * cos( 2.0f * APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
+    start[2] = centre_xyz[2] + radius * sinf( 2.0f * (float)APG_GLDB_PI * (float)i / (float)segs );
+    end[0]   = centre_xyz[0] + radius * cosf( 2.0f * (float)APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
     end[1]   = centre_xyz[1];
-    end[2]   = centre_xyz[2] + radius * sin( 2.0f * APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
+    end[2]   = centre_xyz[2] + radius * sinf( 2.0f * (float)APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
     apg_gldb_add_line( start, end, colour_rgba );
   }
   // y,z around xloop
   for ( int i = 0; i < segs; i++ ) {
     start[0] = centre_xyz[0];
-    start[1] = centre_xyz[1] + radius * cos( 2.0f * APG_GLDB_PI * (float)i / (float)segs );
-    start[2] = centre_xyz[2] + radius * sin( 2.0f * APG_GLDB_PI * (float)i / (float)segs );
+    start[1] = centre_xyz[1] + radius * cosf( 2.0f * (float)APG_GLDB_PI * (float)i / (float)segs );
+    start[2] = centre_xyz[2] + radius * sinf( 2.0f * (float)APG_GLDB_PI * (float)i / (float)segs );
     end[0]   = centre_xyz[0];
-    end[1]   = centre_xyz[1] + radius * cos( 2.0f * APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
-    end[2]   = centre_xyz[2] + radius * sin( 2.0f * APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
+    end[1]   = centre_xyz[1] + radius * cosf( 2.0f * (float)APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
+    end[2]   = centre_xyz[2] + radius * sinf( 2.0f * (float)APG_GLDB_PI * (float)( i + 1 ) / (float)segs );
     apg_gldb_add_line( start, end, colour_rgba );
   }
 
   return rid;
 }
 
-int apg_gldb_add_frustum( float* ftl, float* ftr, float* fbl, float* fbr, float* ntl, float* ntr, float* nbl, float* nbr, float* colour_rgba ) {
+int apg_gldb_add_frustum( const float* ftl, const float* ftr, const float* fbl, const float* fbr, const float* ntl, const float* ntr, const float* nbl,
+  const float* nbr, const float* colour_rgba ) {
   int rid = -1;
   float start[3], end[3];
   start[0] = ftl[0];
@@ -397,7 +398,7 @@ int apg_gldb_add_frustum( float* ftl, float* ftr, float* fbl, float* fbr, float*
   return rid;
 }
 
-bool apg_gldb_mod_line( uint32_t line_id, float* start_xyz, float* end_xyz, float* colour_rgba ) {
+bool apg_gldb_mod_line( uint32_t line_id, const float* start_xyz, const float* end_xyz, const float* colour_rgba ) {
   if ( line_id >= _count_lines ) {
     fprintf( stderr, "ERROR: modifying apg_gldb line - bad ID\n" );
     return false;
@@ -427,7 +428,7 @@ bool apg_gldb_mod_line( uint32_t line_id, float* start_xyz, float* end_xyz, floa
   return true;
 }
 
-bool apg_gldb_mod_aabb( uint32_t line_id, float* min_xyz, float* max_xyz, float* colour_rgba ) {
+bool apg_gldb_mod_aabb( uint32_t line_id, const float* min_xyz, const float* max_xyz, const float* colour_rgba ) {
   if ( line_id + 12 > _count_lines ) {
     fprintf( stderr, "ERROR: modifying apg_gldb AABB - bad line ID\n" );
     return false;
@@ -491,7 +492,8 @@ bool apg_gldb_mod_aabb( uint32_t line_id, float* min_xyz, float* max_xyz, float*
   return true;
 }
 
-bool apg_gldb_mod_frustum( uint32_t line_id, float* ftl, float* ftr, float* fbl, float* fbr, float* ntl, float* ntr, float* nbl, float* nbr, float* colour_rgba ) {
+bool apg_gldb_mod_frustum( uint32_t line_id, const float* ftl, const float* ftr, const float* fbl, const float* fbr, const float* ntl, const float* ntr,
+  const float* nbl, const float* nbr, const float* colour_rgba ) {
   if ( line_id + 12 > _count_lines ) {
     fprintf( stderr, "ERROR: modifying apg_gldb frustum - bad line ID\n" );
     return false;
@@ -588,7 +590,7 @@ bool apg_gldb_mod_frustum( uint32_t line_id, float* ftl, float* ftr, float* fbl,
   return true;
 }
 
-void apg_gldb_update_cam( float* PV_mat4 ) {
+void apg_gldb_update_cam( const float* PV_mat4 ) {
   glUseProgram( _lines_shader_program );
   glUniformMatrix4fv( _PV_loc, 1, GL_FALSE, PV_mat4 );
 }

--- a/apg_gldb/apg_gldb.h
+++ b/apg_gldb/apg_gldb.h
@@ -23,9 +23,11 @@ USAGE INSTRUCTIONS
  6. Call apg_gldb_free() when done i.e. at the end of your program.
 
 HISTORY
-  0.1 - 11 Jun 2015 - First version.
-  0.2 - 16 Jun 2015 - Feature complete v. original spec.
-  0.3 - 13 May 2020 - Tidied API and docs. Added _mod_ function for AABB and frustum.
+  0.4.1 - 2023/04/19  - Compiler warning tweaks.
+  0.4   - 18 May 2020 - const.
+  0.3   - 13 May 2020 - Tidied API and docs. Added _mod_ function for AABB and frustum.
+  0.2   - 16 Jun 2015 - Feature complete v. original spec.
+  0.1   - 11 Jun 2015 - First version.
 
 TODO
  - Recreate test/example program.
@@ -40,10 +42,10 @@ TODO
 #define APG_GLDB_MAX_LINES 10000
 
 /* Reserves memory for drawing and creates GPU resources. */
-bool apg_gldb_init();
+bool apg_gldb_init( void );
 
 /* Frees all allocated memory and GPU resources. */
-void apg_gldb_free();
+void apg_gldb_free( void );
 
 /* Creates a new debug line in world coordinate space.
 PARAMS
@@ -51,7 +53,7 @@ PARAMS
   colour_rgba        - Colour to draw the line.
 RETURNS the line id.
 */
-int apg_gldb_add_line( float* start_xyz, float* end_xyz, float* colour_rgba );
+int apg_gldb_add_line( const float* start_xyz, const float* end_xyz, const float* colour_rgba );
 
 /* Creates a line with a colour that goes from black to coloured in direction of a normal.
 PARAMS
@@ -61,12 +63,12 @@ PARAMS
   colour_rgba - Colour to draw the line.
 RETURNS the line id.
 */
-int apg_gldb_add_normal( float* n_xyz, float* pos_xyz, float scale, float* colour_rgba );
+int apg_gldb_add_normal( const float* n_xyz, const float* pos_xyz, const float scale, const float* colour_rgba );
 
 /* Creates 3 lines in a cross with a colour to show a position.
 RETURNS the first of 3 contiguous line ids.
 */
-int apg_gldb_add_pos( float* pos_xyz, float scale, float* colour_rgba );
+int apg_gldb_add_pos( const float* pos_xyz, const float scale, const float* colour_rgba );
 
 /* Draws a box for this axis-aligned bounding box.
 PARAMS
@@ -75,23 +77,24 @@ PARAMS
   colour_rgba - Colour to render the lines.
 RETURNS the first of 12 contiguous line ids
 */
-int apg_gldb_add_aabb( float* min_xyz, float* max_xyz, float* colour_rgba );
+int apg_gldb_add_aabb( const float* min_xyz, const float* max_xyz, const float* colour_rgba );
 
 /* Draws a circle+radius to represent a sphere.
 RETURNS the first of 39 line ids
 */
-int apg_gldb_add_rad_circle( float* centre_xyz, float radius, float* colour_rgba );
+int apg_gldb_add_rad_circle( const float* centre_xyz, float radius, const float* colour_rgba );
 
 /* Takes 8 xyz corner points for given camera frustum and draws a box whenever apg_gldb_draw() is called.
 Most camera code already extracts points from matrices so that is not repeated here.
 RETURNS first line's id.
 */
-int apg_gldb_add_frustum( float* ftl, float* ftr, float* fbl, float* fbr, float* ntl, float* ntr, float* nbl, float* nbr, float* colour_rgba );
+int apg_gldb_add_frustum( const float* ftl, const float* ftr, const float* fbl, const float* fbr, const float* ntl, const float* ntr, const float* nbl,
+  const float* nbr, const float* colour_rgba );
 
 /* Modify or move a line previously added.
 RETURNS false if line_id wasn't valid.
 */
-bool apg_gldb_mod_line( uint32_t line_id, float* start_xyz, float* end_xyz, float* colour_rgba );
+bool apg_gldb_mod_line( uint32_t line_id, const float* start_xyz, const float* end_xyz, const float* colour_rgba );
 
 /* Modify or move an axis-aligned bounding box previously added via apg_gldb_add_aabb().
 PARAMS
@@ -102,18 +105,19 @@ PARAMS
 RETURNS false if line_id wasn't valid.
 TODO(Anton) - the impl of this should modifier the buffer in one op, not individual calls to apg_gldb_mod_line().
 */
-bool apg_gldb_mod_aabb( uint32_t line_id, float* min_xyz, float* max_xyz, float* colour_rgba );
+bool apg_gldb_mod_aabb( uint32_t line_id, const float* min_xyz, const float* max_xyz, const float* colour_rgba );
 
-bool apg_gldb_mod_frustum( uint32_t line_id, float* ftl, float* ftr, float* fbl, float* fbr, float* ntl, float* ntr, float* nbl, float* nbr, float* colour_rgba );
+bool apg_gldb_mod_frustum( uint32_t line_id, const float* ftl, const float* ftr, const float* fbl, const float* fbr, const float* ntl, const float* ntr,
+  const float* nbl, const float* nbr, const float* colour_rgba );
 
 /* Wipes all the lines for redrawing. Doesn't actually delete the buffer - call apg_gldb_free() do release allocated graphics resources. */
-void apg_gldb_reset_lines();
+void apg_gldb_reset_lines( void );
 
 /* Updates the camera matrix so that line points given are defined as being in world coordinate space.
 PARAMS
   matrix - A 16 float column-major matrix as 1D array in column order.
 */
-void apg_gldb_update_cam( float* PV_mat4 );
+void apg_gldb_update_cam( const float* PV_mat4 );
 
 /* Draws the lines.
 PARAMS

--- a/apg_interp/tests/test.c
+++ b/apg_interp/tests/test.c
@@ -4,7 +4,7 @@
 #include <unistd.h> // unix sleep
 #include <stdbool.h>
 
-int main() {
+int main( void ) {
   printf( "hello world\n" );
   time_t prev_time, curr_time;
   time( &prev_time );

--- a/apg_jobs/apg_jobs.c
+++ b/apg_jobs/apg_jobs.c
@@ -3,7 +3,7 @@
  *
  * apg_jobs  | Threaded jobs/worker library.
  * --------- | ----------
- * Version   | 0.2.3
+ * Version   | 0.2.4
  * Authors   | Anton Gerdelan https://github.com/capnramses
  * Language  | C99
  * Files     | 2
@@ -379,7 +379,7 @@ bool apg_jobs_push_job( apg_jobs_pool_t* pool_ptr, apg_jobs_work job_func_ptr, v
 /** Further OS examples:
  * https://stackoverflow.com/questions/150355/programmatically-find-the-number-of-cores-on-a-machine
  */
-unsigned int apg_jobs_n_logical_procs() {
+unsigned int apg_jobs_n_logical_procs( void ) {
 #ifdef _WIN32
   SYSTEM_INFO sys_info;
   GetSystemInfo( &sys_info );

--- a/apg_jobs/apg_jobs.h
+++ b/apg_jobs/apg_jobs.h
@@ -3,7 +3,7 @@
  *
  * apg_jobs  | Threaded jobs/worker library.
  * --------- | ----------
- * Version   | 0.2.3
+ * Version   | 0.2.4
  * Authors   | Anton Gerdelan https://github.com/capnramses
  * Copyright | 2021, Anton Gerdelan
  * Language  | C99
@@ -77,7 +77,7 @@ APG_JOBS_EXPORT typedef struct apg_jobs_pool_t { apg_jobs_pool_internal_t* conte
 typedef void ( *apg_jobs_work )( void* args_ptr );
 
 /** @return The number of logical processors on the system. */
-APG_JOBS_EXPORT unsigned int apg_jobs_n_logical_procs();
+APG_JOBS_EXPORT unsigned int apg_jobs_n_logical_procs( void );
 
 /** Start the jobs system and its threads.
  * @param pool_ptr       The pool pointed to will be initialised by this function. Must not be NULL.

--- a/apg_jobs/tests/main.c
+++ b/apg_jobs/tests/main.c
@@ -37,7 +37,7 @@ void work_cb( void* arg_ptr ) {
   fprintf( stderr, "ending job, old=%d, val=%d\n", old, *val );
 }
 
-int main() {
+int main( void ) {
   // similar to `lscpu` command, where my machine has 1 socket with 4 cores per socket
   // and 2 threads per core (8 logical, 4 physical).
   int n_procs = apg_jobs_n_logical_procs();

--- a/apg_maths/apg_maths.c
+++ b/apg_maths/apg_maths.c
@@ -1,6 +1,6 @@
 /* ===============================================================================================
 Anton's 3D Maths Library (C99 version)
-Version: 0.16
+Version: 0.16.1
 URL:     https://github.com/capnramses/apg
 Licence: See apg_maths.h
 Author:  Anton Gerdelan <antonofnote at gmail> @capnramses
@@ -116,7 +116,7 @@ vec3 reject_vec3( vec3 a, vec3 b ) {
    Basic Matrix Functions
 =============================================================================================== */
 
-mat4 identity_mat4() {
+mat4 identity_mat4( void ) {
   mat4 r  = { { 0 } };
   r.m[0]  = 1.0f;
   r.m[5]  = 1.0f;

--- a/apg_maths/apg_maths.h
+++ b/apg_maths/apg_maths.h
@@ -5,6 +5,7 @@ Licence: See bottom of file.
 Author:  Anton Gerdelan  <antonofnote at gmail>  @capnramses
 ==================================================================================================
 History:
+v0.16.1 2023/04/19 - Minor tweaks for compiler warnings.
 v0.16  06 Apr 2022 - Added mul_vec2_f().
 v0.15  02 Feb 2022 - Added vec3 projection and rejection, added detail to comments, and tidied code formatting.
 v0.14  18 Jan 2022 - Added a couple of vec2 functions.
@@ -190,7 +191,7 @@ vec3 reject_vec3( vec3 a, vec3 b );
    Basic Matrix Functions
 =============================================================================================== */
 
-mat4 identity_mat4();
+mat4 identity_mat4( void );
 
 mat4 mul_mat4_mat4( mat4 a, mat4 b );
 

--- a/apg_maths/tests/test.c
+++ b/apg_maths/tests/test.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h> // memset
 
-int main() {
+int main( void ) {
   printf( "testing C99 version of maths library\n" );
 
   // vec2 v2, v2b;

--- a/apg_plot/apg_plot.c
+++ b/apg_plot/apg_plot.c
@@ -4,7 +4,7 @@ Author:   Anton Gerdelan  <antonofnote at gmail>  @capnramses
 URL:      https://github.com/capnramses/apg
 Licence:  See bottom of corresponding header file.
 Language: C99.
-Version:  0.2
+Version:  0.2.1
 ==================================================================================================
 */
 
@@ -211,7 +211,7 @@ void apg_plot_y_axis_colour( uint8_t r, uint8_t g, uint8_t b ) {
 #define _APG_PLOT_TEST_PX_Y 512
 #define _APG_PLOT_TEST_N 32
 
-int main() {
+int main( void ) {
   // Init some test data. I want to plot n values, between 0 ant 2pi on x. Any value of n is fine.
   float xy_array[_APG_PLOT_TEST_N * 2];
   for ( int i = 0; i < _APG_PLOT_TEST_N; i++ ) {

--- a/apg_plot/apg_plot.h
+++ b/apg_plot/apg_plot.h
@@ -32,8 +32,9 @@ TODO:
  * Maybe add tics to axes. Possibly also an optional apg_pixel_font text or so.
 ==================================================================================================
 History:
-  0.2     - 20 JUL 2022 - Export symbols and renamed to apg_plot because its shorter and cooler.
-  0.1     - 20 JUL 2022 - First version in apg libraries. Pulled from hobby project and tidied up.
+  0.2.1   - 2023/04/19 - Minor compiler warning tweaks.
+  0.2     - 2022/07/20 - Export symbols and renamed to apg_plot because its shorter and cooler.
+  0.1     - 2022/07/20 - First version in apg libraries. Pulled from hobby project and tidied up.
 ==================================================================================================
 */
 

--- a/apg_wav/tests/main_write.c
+++ b/apg_wav/tests/main_write.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <math.h>
 
-int main() {
+int main( void ) {
   int n_chans         = 1;
   int sample_rate     = 11025;
   int n_samples       = 1024;


### PR DESCRIPTION
* Updated my dev Linux machine and the latest GCC with `-Wstrict-prototypes` gives multiple warnings where functions with no parameters needed `void` as a parameter.
* This improves robustness to accidental and intentional errors.
* Bumps to patch number in most apg libraries.