### PR TITLE
Apg bmp compression1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Small utility libraries and copy-paste snippets of reusable code.
 | Library     | Description                                     | Language | # Files         | Version | Fuzzed With                             |
 |-------------|-------------------------------------------------|----------|-----------------|---------|-----------------------------------------|
 | apg         | Generic C programming utils.                    | C        | 1               | 1.13    | No                                      |
-| apg_bmp     | BMP bitmap image reader/writer library.         | C        | 2               | 3.3     | [AFL](https://lcamtuf.coredump.cx/afl/) |
+| apg_bmp     | BMP bitmap image reader/writer library.         | C        | 2               | 3.4     | [AFL](https://lcamtuf.coredump.cx/afl/) |
 | apg_console | Quake-style graphical console. API-independent. | C        | 2 + apg_pixfont | 0.13    | No                                      |
 | apg_jobs    | Simple worker/jobs thread pool system.          | C        | 2               | 0.2     | No                                      |
 | apg_gldb    | OpenGL debug drawing (lines, boxes, ... )       | C        | 2               | 0.3     | No                                      |

--- a/apg_bmp/apg_bmp.c
+++ b/apg_bmp/apg_bmp.c
@@ -276,6 +276,23 @@ unsigned char* apg_bmp_read( const char* filename, int* w, int* h, unsigned int*
       src_byte_idx += row_padding_sz;
     }
 
+
+    /* TODO
+    
+    1. fix up remaining TODOs.
+    2. maybe leave out 4-bit RLE for now. Not sure how to get a test sample other than from MSN docs.
+    3. Validate sizes where e.g. byte_idx increases inside loop.
+    4. Validate row widths where e.g. a line end is missing.
+    5. Handle files where EOF is missing.
+    6. Check when EOF escape is sent that all w*h were written.
+    7. Maybe just don't support the weird delta escape since I don't have decent docs/examples and I
+       don't think it will be used for many cases except for old files.
+    8. Use in antonkraft for some experience before release.
+    9. Fuzz it on HDD (not SSD) with some new example RLE images.
+   10. Main repo Readme update.
+   11. Release/notes announce.
+    */
+
     // == 8-bpp -> 24-bit RGB ==
   } else if ( 8 == dib_hdr_ptr->bpp && has_palette ) {
     if ( BI_RLE8 == dib_hdr_ptr->compression_method ) {

--- a/apg_bmp/apg_bmp.c
+++ b/apg_bmp/apg_bmp.c
@@ -1,7 +1,7 @@
 /*****************************************************************************\
 apg_bmp - BMP File Reader/Writer Implementation
 Anton Gerdelan
-Version: 3.3.1
+Version: 3.4.0
 Licence: see apg_bmp.h
 C99
 \*****************************************************************************/
@@ -131,6 +131,7 @@ static uint32_t _bitscan( uint32_t dword ) {
   return 0;
 }
 
+// TODO(Anton) - use stat ftello to allow >2GB files? and dir stat? Snippets in apg.h.
 unsigned char* apg_bmp_read( const char* filename, int* w, int* h, unsigned int* n_chans ) {
   if ( !filename || !w || !h || !n_chans ) { return NULL; }
 

--- a/apg_bmp/apg_bmp.c
+++ b/apg_bmp/apg_bmp.c
@@ -54,6 +54,8 @@ typedef struct _bmp_dib_BITMAPINFOHEADER_t {
   uint32_t bitmask_r;
   uint32_t bitmask_g;
   uint32_t bitmask_b;
+  // TODO(Anton) bitmask_a; is here in v4 and v5.
+  // Note(Anton) v4 and v5 have gamma curve and sRGB information here. 
 } _bmp_dib_BITMAPINFOHEADER_t;
 #pragma pack( pop )
 
@@ -182,7 +184,7 @@ unsigned char* apg_bmp_read( const char* filename, int* w, int* h, unsigned int*
     has_palette = true;
     n_src_chans = 1;
     break;
-  default: // this includes 2bpp and 16bpp
+  default: // This includes 0 (PNG and JPG) and 16.
     free( record.data );
     return NULL;
   } // endswitch

--- a/apg_bmp/apg_bmp.c
+++ b/apg_bmp/apg_bmp.c
@@ -109,6 +109,8 @@ static bool _validate_file_hdr( _bmp_file_header_t* file_hdr_ptr, size_t file_sz
 static bool _validate_dib_hdr( _bmp_dib_BITMAPINFOHEADER_t* dib_hdr_ptr, size_t file_sz ) {
   if ( !dib_hdr_ptr ) { return false; }
   if ( _BMP_FILE_HDR_SZ + dib_hdr_ptr->this_header_sz > file_sz ) { return false; }
+  // TODO(Anton) a 32-bit image is allowed to use BI_RGB for compression. Then high bit (alpha) is ignored.
+  // https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapv5header
   if ( ( 32 == dib_hdr_ptr->bpp || 16 == dib_hdr_ptr->bpp ) && ( BI_BITFIELDS != dib_hdr_ptr->compression_method && BI_ALPHABITFIELDS != dib_hdr_ptr->compression_method ) ) {
     return false;
   }

--- a/apg_bmp/apg_bmp.h
+++ b/apg_bmp/apg_bmp.h
@@ -1,10 +1,3 @@
-
-/* TODO
-9. Fuzz it on HDD (not SSD) with some new example RLE images.
-10. Main repo Readme update.
-11. Release/notes announce.
-*/
-
 /*****************************************************************************\
 apg_bmp - A BMP File Reader/Writer Library
 -------------------------------------------------------------------------------

--- a/apg_bmp/apg_bmp.h
+++ b/apg_bmp/apg_bmp.h
@@ -1,9 +1,18 @@
+
+/* TODO
+9. Fuzz it on HDD (not SSD) with some new example RLE images.
+10. Main repo Readme update.
+11. Release/notes announce.
+*/
+
 /*****************************************************************************\
 apg_bmp - A BMP File Reader/Writer Library
+-------------------------------------------------------------------------------
 Original author: Anton Gerdelan
 Project URL:     https://github.com/capnramses/apg
 Licence:         See bottom of file.
 Language:        C89 ( Implementation is C99 )
+-------------------------------------------------------------------------------
 
 Contributors
 -------------------------------------------------------------------------------
@@ -12,62 +21,66 @@ Contributors
 
 Instructions
 -------------------------------------------------------------------------------
-- Just drop this header, and the matching .c file into your project.
-- If in a C++ project set these files to build as C, not C++.
-- To get debug printouts during parsing define APG_BMP_DEBUG_OUTPUT.
+  - Just drop this header, and the matching .c file into your project.
+  - If in a C++ project set these files to build as C, not C++.
+  - To get debug printouts during parsing define APG_BMP_DEBUG_OUTPUT.
 
-Advantages
+Features
 -------------------------------------------------------------------------------
-- Fast, simple, and supports more sub-formats than most BMP libraries.
-- The reader function is fuzzed with AFL https://lcamtuf.coredump.cx/afl/.
-- The reader is robust to large files and malformed files, and will return
-  any valid partial data in an image.
-- Reader supports 32bpp (with alpha channel), 24bpp, 8bpp, 4bpp, and 1bpp
-  monochrome BMP images.
-- Reader handles indexed BMP images using a colour palette.
-- Writer supports 32bpp RGBA and 24bpp uncompressed RGB images.
+  - Fast, simple, and supports more sub-formats than most BMP libraries.
+  - The reader function is fuzzed with AFL https://lcamtuf.coredump.cx/afl/.
+  - The reader is robust to large files and malformed files, and will, in some
+    cases, return any valid partial data in an image.
+  - Reader supports 32bpp (with alpha channel), 24bpp, 8bpp, 4bpp, and 1bpp
+    monochrome BMP images.
+  - Reader handles indexed BMP images using a colour palette.
+  - Reader supports 8-bit and 4-bit RLE compression.
+  - Writer supports 32bpp RGBA and 24bpp uncompressed RGB images.
 
 Current Limitations
 -------------------------------------------------------------------------------
-- 16-bit images not supported (don't have any samples to test on).
-- No support for interleaved channel bit layouts;
-  e.g. RGB101010 RGB555 RGB565.
-- 4-bit variation of RLE compression not supported (yet).
-- Images with alpha channel are written in BITMAPINFOHEADER format for maximum
-  backwards-compatibility. For wider alpha support in other apps the 124-bit v5
-  header could be used instead. Your own apps using apg_bmp_read() will still
-  read the alpha channel correctly.
-- Gamma curves from v4 and v5 bitmap headers are ignored.
-- Images over 2GB are not supported, but could be added if needed.
+  - Because I don't have any samples to test on, the following are not supported:
+    - 16-bit images.
+    - Interleaved channel bit layouts; e.g. RGB101010 RGB555 RGB565.
+    - Delta position escape codes in RLE.
+  - Alpha channels are written in BITMAPINFOHEADER, which covers most cases,
+    and supports older software. For wider alpha support in other apps the v5
+    header could be used.
+  - Gamma curves from v4 and v5 bitmap headers are ignored.
+  - Maximum image dimensions are set to 65536*65536 as a safe maximum for
+    interoperability with other software. See _BMP_MAX_DIMS to change this.
+  - Images over 2GB are not supported, but could be by replacing ftell/fseek
+    with platform-specific #ifdefs for 64-bit equivalents (ftello, stat, etc.).
 
 FAQ
 -------------------------------------------------------------------------------
 Q. What makes this image loader special? Why would I use it?
 
-This library started as a curiosity project, to see if I could read really old
-BMP files, and understand the format. It was then used as an example for a
-security class learning fuzzing. Because it was fuzzed it was used in some very
-large projects as an image loader. There are many other BMP loaders out there,
-but this one is pretty small and fast, and can handle some very old formats
-that are not broadly supported. There is a blog post about it here:
-https://antongerdelan.net/blog/formatted/2020_03_24_apg_bmp.html
+  This library started as a curiosity project, to see if I could read really
+  old BMP files, and understand the format. It was then used as an example for
+  a security class learning fuzzing. Because it was fuzzed it was used in some
+  very large projects as an image loader. There are many other BMP loaders,
+  but this one is pretty small and fast, and can handle some very old formats
+  that are not broadly supported. There is a blog post about it here:
+  https://antongerdelan.net/blog/formatted/2020_03_24_apg_bmp.html
 
 Q. Why won't this compile in my C++ project?
 
-This is a C library, just make sure the apg_bmp.c file is set to compile as C,
-not C++. Then the compiled object file will compile in with your C++ program.
+  This is a C library, just make sure the apg_bmp.c file is set to compile as
+  C, not C++. Then the compiled object file will compile in with your C++
+  program.
 
 Q. Are you open to pull requests?
 
-Yes, but it's not being actively worked on, so turn-around time may be slow.
-If the PR is accepted, I'll add you to the Contributors list.
+  Yes, but it's not being actively worked on, so turn-around time may be slow.
+  If the PR is accepted, I'll add you to the Contributors list.
 
 Welcome:       Bug fixes, BMP feature-handling improvement.
 Not desired:   Build systems, language & code style changes, large PRs.
 
 Version History
 -------------------------------------------------------------------------------
-  3.4.0   - 2023 May. 29. 8-bit RLE compression support added.
+  3.4.0   - 2023 May. 31. 8-bit and 4-bit RLE compression support added.
   3.3.1   - 2023 Feb.  1. Fixed type casting warnings from MSVC.
   3.3     - 2023 Jan. 11. Fixed bug: images with alpha channel were y-flipped.
   3.2     - 2022 Mar. 22. Minor signed/unsigned tweaks to constants.

--- a/apg_bmp/apg_bmp.h
+++ b/apg_bmp/apg_bmp.h
@@ -67,6 +67,7 @@ Not desired:   Build systems, language & code style changes, large PRs.
 
 Version History
 -------------------------------------------------------------------------------
+  3.4.0   - 2023 May. 29. RLE compression support added.
   3.3.1   - 2023 Feb.  1. Fixed type casting warnings from MSVC.
   3.3     - 2023 Jan. 11. Fixed bug: images with alpha channel were y-flipped.
   3.2     - 2022 Mar. 22. Minor signed/unsigned tweaks to constants.

--- a/apg_bmp/apg_bmp.h
+++ b/apg_bmp/apg_bmp.h
@@ -18,8 +18,7 @@ Instructions
 
 Advantages
 -------------------------------------------------------------------------------
-- The implementation is fast, simple, and supports more formats than most
-  BMP reader libraries.
+- Fast, simple, and supports more sub-formats than most BMP libraries.
 - The reader function is fuzzed with AFL https://lcamtuf.coredump.cx/afl/.
 - The reader is robust to large files and malformed files, and will return
   any valid partial data in an image.
@@ -33,12 +32,13 @@ Current Limitations
 - 16-bit images not supported (don't have any samples to test on).
 - No support for interleaved channel bit layouts;
   e.g. RGB101010 RGB555 RGB565.
-- No support for compressed BMP images, although in practice these are
-  not used.
+- 4-bit variation of RLE compression not supported (yet).
 - Images with alpha channel are written in BITMAPINFOHEADER format for maximum
   backwards-compatibility. For wider alpha support in other apps the 124-bit v5
   header could be used instead. Your own apps using apg_bmp_read() will still
   read the alpha channel correctly.
+- Gamma curves from v4 and v5 bitmap headers are ignored.
+- Images over 2GB are not supported, but could be added if needed.
 
 FAQ
 -------------------------------------------------------------------------------
@@ -55,7 +55,7 @@ https://antongerdelan.net/blog/formatted/2020_03_24_apg_bmp.html
 Q. Why won't this compile in my C++ project?
 
 This is a C library, just make sure the apg_bmp.c file is set to compile as C,
-not C++, and the compiled object file will compile in with your C++ program.
+not C++. Then the compiled object file will compile in with your C++ program.
 
 Q. Are you open to pull requests?
 
@@ -67,7 +67,7 @@ Not desired:   Build systems, language & code style changes, large PRs.
 
 Version History
 -------------------------------------------------------------------------------
-  3.4.0   - 2023 May. 29. RLE compression support added.
+  3.4.0   - 2023 May. 29. 8-bit RLE compression support added.
   3.3.1   - 2023 Feb.  1. Fixed type casting warnings from MSVC.
   3.3     - 2023 Jan. 11. Fixed bug: images with alpha channel were y-flipped.
   3.2     - 2022 Mar. 22. Minor signed/unsigned tweaks to constants.

--- a/apg_bmp/tests_fuzzing/fuzz_24bpp.sh
+++ b/apg_bmp/tests_fuzzing/fuzz_24bpp.sh
@@ -12,5 +12,5 @@ mkdir $OUTDIR
 afl-gcc -g -o $BIN fuzz_main.c ../apg_bmp.c -I ../
 
 #run with fuzz
-AFL_EXIT_WHEN_DONE=1 AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+AFL_EXIT_WHEN_DONE=1 AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
 AFL_SKIP_CPUFREQ=1 afl-fuzz -i $INDIR/ -o $OUTDIR/ -- ./$BIN @@

--- a/apg_bmp/tests_fuzzing/fuzz_32bpp.sh
+++ b/apg_bmp/tests_fuzzing/fuzz_32bpp.sh
@@ -12,5 +12,5 @@ mkdir $OUTDIR
 afl-gcc -g -o $BIN fuzz_main.c ../apg_bmp.c -I ../
 
 #run with fuzz
-AFL_EXIT_WHEN_DONE=1 AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
-AFL_SKIP_CPUFREQ=1 afl-fuzz -i $INDIR/ -o $OUTDIR/ -- ./$BIN @@
+AFL_EXIT_WHEN_DONE=1 AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_SKIP_CPUFREQ=1 \
+afl-fuzz -i $INDIR/ -o $OUTDIR/ -- ./$BIN @@


### PR DESCRIPTION
Description
---------------

* This update adds support for RLE  (run-length encoding) 8 and 4-bit compression (as exported as a checkbox option by GIMP).
* For projects using BMP as a simple/fast/editable image format it's quite handy to have a lossless compression option that can give 5-10x compression.
* I developed this feature based on Microsoft's BMP RLE documentation. https://learn.microsoft.com/en-us/windows/win32/gdi/bitmap-compression
* Most historical samples of BMPs did not implement compression, which is why I didn't originally support this (hard to test), but I specifically wanted to support the same compression as exported by GIMP.
* It turns out GIMP decides, based on the image, if it will use RLE4 or RLE8 compression. In my test project I ended up with a mix of standards, so I was able to support and test both.
* Note that images with an alpha channel can not use this compression because they use one of two types of "BITMASK" in the compression field instead.
* This PR does not attempt to support other compression formats (JPG, PNG, etc). I have not found an example of any other formats used.
* I was not able to find reliable examples of images using the "delta position" escape code, so I do not support that here. Official documentation was fairly ambiguous as to how to treat that, and I don't implement anything I can't test.
* Note that BMP RLE compression only worked on indexed (palette-based) 3-channel images.
* Note that this PR does not include an option for _writing_ RLE images. That could be easily done in an update.

Changes
------------

* Added code to the appropriate image sub-formats.
* In-line documentation updated.
* Several security/bug vulnerabilities fixed after a round of fuzzing.
* Version bump to 3.4.0.

Testing Summary
-----------------------

* Converted the entire corpus of textures in a game project to BMP with indexing, exported from GIMP with the compression option checked (except images with an alpha channel), and made sure they all loaded and displayed correctly.
* Using test_read_bmp I visually compared the PNG output of several BMP images to their originals.
* Ran both included fuzzing scripts using AFL++ for several cycles each. Fixed and repeated the process after any crashes were found until none were reported.
* Included assertions at pain point traps, and extensively debugging the reading process.

Risk
------------------------

* I only compiled the project with GCC 11.3 on Ubuntu LTS. I expect several type changes and small tweaks will be required after compiling with MSVC and Clang.
* I updated error handling after fuzzing which looks good but may changed the catch/miss robustness surface area inadvertently.

Future Work
-----------------

* I'll add and flesh out any missing features as requested, but I'll need some samples to test with.